### PR TITLE
[Feature] 마이페이지 정보 조회 API 구현

### DIFF
--- a/src/main/java/ewha/lux/once/domain/home/dto/AnnounceDetailDto.java
+++ b/src/main/java/ewha/lux/once/domain/home/dto/AnnounceDetailDto.java
@@ -17,7 +17,7 @@ public class AnnounceDetailDto {
         this.content = announce.getContent();
         this.moreInfo = announce.getMoreInfo();
         this.type = announce.getType();
-        this.announceDate = announce.getCreated_at().format(DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss"));
+        this.announceDate = announce.getCreatedAt().format(DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss"));
     }
 
 }

--- a/src/main/java/ewha/lux/once/domain/home/dto/AnnounceDto.java
+++ b/src/main/java/ewha/lux/once/domain/home/dto/AnnounceDto.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.stream.Collector;
 
 @Getter
 @Setter
@@ -22,7 +20,7 @@ public class AnnounceDto {
         this.content = announce.getContent();
         this.type = announce.getType();
         this.hasCheck = announce.isHasCheck();
-        this.announceDate = announce.getCreated_at().format(DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss"));
+        this.announceDate = announce.getCreatedAt().format(DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss"));
     }
 
 }

--- a/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
@@ -118,22 +118,22 @@ public class HomeService {
 
         // 오늘 생성된 알림
         List<AnnounceDto> todayAnnounceDto = announcementList.stream()
-                .filter(announcement -> announcement.getCreated_at().toLocalDate().isEqual(today))
-                .sorted(Comparator.comparing(Announcement::getCreated_at).reversed())
+                .filter(announcement -> announcement.getCreatedAt().toLocalDate().isEqual(today))
+                .sorted(Comparator.comparing(Announcement::getCreatedAt).reversed())
                 .map(AnnounceDto::new)
                 .collect(Collectors.toList());
 
         // 7일 이내에 생성된 알림 (오늘 제외)
         List<AnnounceDto> recentAnnounceDto = announcementList.stream()
-                .filter(announcement -> !announcement.getCreated_at().toLocalDate().isEqual(today)
-                        && announcement.getCreated_at().toLocalDate().isAfter(thisWeek))
-                .sorted(Comparator.comparing(Announcement::getCreated_at).reversed())
+                .filter(announcement -> !announcement.getCreatedAt().toLocalDate().isEqual(today)
+                        && announcement.getCreatedAt().toLocalDate().isAfter(thisWeek))
+                .sorted(Comparator.comparing(Announcement::getCreatedAt).reversed())
                 .map(AnnounceDto::new)
                 .collect(Collectors.toList());
 
         long uncheckedcnt = announcementList.stream()
                 .filter(announcement -> !announcement.isHasCheck()
-                        && announcement.getCreated_at().toLocalDate().isAfter(thisWeek))
+                        && announcement.getCreatedAt().toLocalDate().isAfter(thisWeek))
                 .count();
 
         return new AnnouncListDto(uncheckedcnt,todayAnnounceDto,recentAnnounceDto);

--- a/src/main/java/ewha/lux/once/domain/mypage/controller/MypageController.java
+++ b/src/main/java/ewha/lux/once/domain/mypage/controller/MypageController.java
@@ -1,0 +1,30 @@
+package ewha.lux.once.domain.mypage.controller;
+
+import ewha.lux.once.domain.mypage.service.MypageService;
+import ewha.lux.once.global.common.CommonResponse;
+import ewha.lux.once.global.common.CustomException;
+import ewha.lux.once.global.common.ResponseCode;
+import ewha.lux.once.global.common.UserAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MypageController {
+
+    private final MypageService mypageService;
+
+    // [Get] 마이페이지 정보 조회
+    @GetMapping("")
+    public CommonResponse<?> mypageInfo(@AuthenticationPrincipal UserAccount user) {
+        try {
+            return new CommonResponse<>(ResponseCode.SUCCESS, mypageService.getMypageInfo(user.getUsers()));
+        } catch (CustomException e) {
+            return new CommonResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/ewha/lux/once/domain/mypage/dto/MypageResponseDto.java
+++ b/src/main/java/ewha/lux/once/domain/mypage/dto/MypageResponseDto.java
@@ -1,0 +1,21 @@
+package ewha.lux.once.domain.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MypageResponseDto {
+
+    private String nickname;
+    private String userProfileImg;
+    private int ownedCardCount;
+    private int month;
+    private int receivedBenefit;
+    private int benefitGoal;
+
+}

--- a/src/main/java/ewha/lux/once/domain/mypage/service/MypageService.java
+++ b/src/main/java/ewha/lux/once/domain/mypage/service/MypageService.java
@@ -1,0 +1,57 @@
+package ewha.lux.once.domain.mypage.service;
+
+import ewha.lux.once.domain.card.entity.OwnedCard;
+import ewha.lux.once.domain.home.entity.ChatHistory;
+import ewha.lux.once.domain.mypage.dto.MypageResponseDto;
+import ewha.lux.once.domain.user.entity.Users;
+import ewha.lux.once.global.common.CustomException;
+import ewha.lux.once.global.repository.ChatHistoryRepository;
+import ewha.lux.once.global.repository.OwnedCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MypageService {
+
+    private final OwnedCardRepository ownedCardRepository;
+    private final ChatHistoryRepository chatHistoryRepository;
+
+
+    public MypageResponseDto getMypageInfo(Users nowUser) throws CustomException {
+
+        // 보유 카드 목록
+        List<OwnedCard> ownedCards = ownedCardRepository.findOwnedCardByUsers(nowUser);
+
+        // 현재 월
+        LocalDate currentDate = LocalDate.now();
+        int currentMonth = currentDate.getMonthValue();
+
+        // 받은 혜택 총합 계산
+        LocalDateTime startOfMonth = LocalDateTime.now().withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime endOfMonth = startOfMonth.with(TemporalAdjusters.lastDayOfMonth()).withHour(23).withMinute(59).withSecond(59);
+
+        List<ChatHistory> hasPaidList = chatHistoryRepository.findByUsersAndHasPaidIsTrueAndCreatedAtBetween(nowUser, startOfMonth, endOfMonth);
+
+        int totalDiscount = hasPaidList.stream()
+                .mapToInt(ChatHistory::getDiscount)
+                .sum();
+
+        MypageResponseDto mypageResponseDto = MypageResponseDto.builder()
+                .nickname(nowUser.getNickname())
+                .userProfileImg(nowUser.getProfileImg())
+                .ownedCardCount(ownedCards.size())
+                .month(currentMonth)
+                .receivedBenefit(totalDiscount)
+                .benefitGoal(nowUser.getBenefitGoal())
+                .build();
+
+        return mypageResponseDto;
+
+    }
+}

--- a/src/main/java/ewha/lux/once/domain/user/dto/UserEditResponseDto.java
+++ b/src/main/java/ewha/lux/once/domain/user/dto/UserEditResponseDto.java
@@ -30,7 +30,7 @@ public class UserEditResponseDto {
         userEditResponseDto.setLoginId(users.getLoginId());
 
 
-        LocalDateTime createdAt = users.getCreated_at();
+        LocalDateTime createdAt = users.getCreatedAt();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         String formattedDate = createdAt.format(formatter);
         userEditResponseDto.setCreatedAt(formattedDate);

--- a/src/main/java/ewha/lux/once/global/common/BaseEntity.java
+++ b/src/main/java/ewha/lux/once/global/common/BaseEntity.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class BaseEntity {
     @CreatedDate
     @Column(name = "createdAt",updatable = false)
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "updatedAt")

--- a/src/main/java/ewha/lux/once/global/repository/ChatHistoryRepository.java
+++ b/src/main/java/ewha/lux/once/global/repository/ChatHistoryRepository.java
@@ -4,8 +4,10 @@ import ewha.lux.once.domain.home.entity.ChatHistory;
 import ewha.lux.once.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
     List<ChatHistory> findByUsers(Users users);
+    List<ChatHistory> findByUsersAndHasPaidIsTrueAndCreatedAtBetween(Users nowUser, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
 }

--- a/src/main/java/ewha/lux/once/global/repository/OwnedCardRepository.java
+++ b/src/main/java/ewha/lux/once/global/repository/OwnedCardRepository.java
@@ -5,7 +5,11 @@ import ewha.lux.once.domain.card.entity.OwnedCard;
 import ewha.lux.once.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OwnedCardRepository extends JpaRepository<OwnedCard, Long> {
     int countAllByUsers( Users users );
     OwnedCard findOwnedCardByCardAndUsers(Card card, Users users);
+
+    List<OwnedCard> findOwnedCardByUsers(Users nowUser);
 }


### PR DESCRIPTION
## ℹ️ PR Type

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #27

## 🔎 작업 내용
- 마이페이지 정보 조회 API 구현
- `chat_history`에서 `has_paid=true`인 것만 더해서 `receivedBenefit` 계산

## 📩 API Test
<p align="center">
<img src="https://github.com/EWHA-LUX/ONCE-BE/assets/94354545/67c6aff8-db3f-4084-a67c-1c38bf6d031e" width="500"/>
</p>


## ➰ ETC
생성날짜 변수명 `created_at` → `createdAt` 으로 변경했습니다!
