### PR TITLE
feat: 카드 검색 시 type(신용카드/체크카드) 추가 (#23)

### DIFF
--- a/src/main/java/ewha/lux/once/domain/user/controller/UserController.java
+++ b/src/main/java/ewha/lux/once/domain/user/controller/UserController.java
@@ -101,9 +101,9 @@ public class UserController {
     // [Get] 카드 이름 검색
     @GetMapping("/card/searchname")
     @ResponseBody
-    public CommonResponse<?> searchCardName(@Param("name") String name) {
+    public CommonResponse<?> searchCardName(@Param("name") String name,@Param("code") String code) {
         try{
-            return new CommonResponse<>(ResponseCode.SUCCESS, userService.getSearchCardName(name));
+            return new CommonResponse<>(ResponseCode.SUCCESS, userService.getSearchCardName(name, code));
         } catch (CustomException e) {
             return new CommonResponse<>(e.getStatus());
         }

--- a/src/main/java/ewha/lux/once/domain/user/dto/CardNameSearchDto.java
+++ b/src/main/java/ewha/lux/once/domain/user/dto/CardNameSearchDto.java
@@ -14,5 +14,6 @@ public class CardNameSearchDto {
     private String cardName;
     private String cardImg;
     private String companyName;
+    private String type;
 
 }

--- a/src/main/java/ewha/lux/once/domain/user/dto/CardSearchDto.java
+++ b/src/main/java/ewha/lux/once/domain/user/dto/CardSearchDto.java
@@ -13,5 +13,6 @@ public class CardSearchDto {
     private Long cardId;
     private String cardName;
     private String cardImg;
+    private String type;
 
 }

--- a/src/main/java/ewha/lux/once/global/config/SecurityConfig.java
+++ b/src/main/java/ewha/lux/once/global/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                     .requestMatchers("/user/duplicate").permitAll()
                     .requestMatchers("/user/login").permitAll()
                     .requestMatchers("/user/auto").permitAll()
-                    .requestMatchers("/user/card/search").permitAll()
+                    .requestMatchers("/user/card/**").permitAll()
                     .anyRequest().authenticated()
             )
             .addFilterBefore(new JwtAuthFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/ewha/lux/once/global/repository/CardCompanyRepository.java
+++ b/src/main/java/ewha/lux/once/global/repository/CardCompanyRepository.java
@@ -3,9 +3,11 @@ package ewha.lux.once.global.repository;
 import ewha.lux.once.domain.card.entity.CardCompany;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CardCompanyRepository extends JpaRepository<CardCompany, Long> {
     Optional<CardCompany> findByCode(String code);
+    List<CardCompany> findByCodeIn(List<String> codes);
 
 }

--- a/src/main/java/ewha/lux/once/global/repository/CardRepository.java
+++ b/src/main/java/ewha/lux/once/global/repository/CardRepository.java
@@ -12,4 +12,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     Optional<Card> findByName(String name);
     List<Card> findAllByNameContains(String name);
     Optional<Card> findCardByName(String name);
+    List<Card> findByNameContainingAndCardCompanyIn(String name, List<CardCompany> cardCompanies);
 }
+


### PR DESCRIPTION
## ℹ️ PR Type

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #23

## 🔎 작업 내용
- 검색 1단계, 2단계에서 type 추가 반환
- 카드 이름 검색 시 카드 회사 필터링 추가

## 📩 API Test
- 카드 검색 1단계
<img width="700" alt="스크린샷 2024-03-22 오전 3 10 29" src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/2b272332-1150-4f3e-83b1-1fa961aaeaac">


- 카드 검색 2단계
<img width="700" alt="스크린샷 2024-03-22 오전 3 09 50" src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/72cb7bf8-8966-4e2f-a8a2-37a6ef664505">


## ➰ ETC
