### PR TITLE
[Feature] 홈 기본 정보 응답 추가

### DIFF
--- a/src/main/java/ewha/lux/once/domain/home/dto/HomeDto.java
+++ b/src/main/java/ewha/lux/once/domain/home/dto/HomeDto.java
@@ -11,5 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 public class HomeDto {
     private String nickname;
+    private int ownedCardCount;
     private List<String> keywordList;
 }

--- a/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
@@ -53,7 +53,7 @@ public class HomeService {
             benefit = (String) map.get("혜택 정보");
             discount = (Integer) map.get("할인 금액");
 
-        } catch ( JsonProcessingException e) {
+        } catch (JsonProcessingException e) {
             throw new CustomException(ResponseCode.FAILED_TO_OPENAI_RECOMMEND);
         }
 
@@ -145,6 +145,10 @@ public class HomeService {
             String keyword = chatHistory.getKeyword();
             keywordFrequencyMap.put(keyword, keywordFrequencyMap.getOrDefault(keyword, 0) + 1);
         }
+
+        int ownedCardCount = ownedCardRepository.countAllByUsers(nowUser);
+
+
         // 빈도수가 높은 순서로 정렬
         List<String> topKeywords = keywordFrequencyMap.entrySet().stream()
                 .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
@@ -156,7 +160,7 @@ public class HomeService {
             topKeywords.add(defaultKeywords.get(topKeywords.size()));
         }
 
-        return new HomeDto(nowUser.getNickname(), topKeywords);
+        return new HomeDto(nowUser.getNickname(), ownedCardCount, topKeywords);
 
     }
 


### PR DESCRIPTION
## ℹ️ PR Type

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #8

## 🔎 작업 내용
- 홈 화면 기본 정보 응답에 `ownedCardCount` 추가

## 📩 API Test
<p align="center">
<img src="https://github.com/EWHA-LUX/ONCE-BE/assets/94354545/3ab7c8dc-e1ed-4486-a2b0-229f64ba03b0" width="500"/>
</p>

## ➰ ETC
카드 추천 api 응답에도 `ownedCardCount` 있는데, 응답 오는 시간 고려해서 홈 화면 기본 정보에도 추가했습니다! 🙃