### PR TITLE
[Fix] 홈화면 검색 키워드 중복 제거

### DIFF
--- a/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
@@ -154,9 +154,10 @@ public class HomeService {
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
         List<String> defaultKeywords = List.of("배달의 민족", "스타벅스", "GS25"); // 고정 키워드
-        while (topKeywords.size() < 3) {
-            topKeywords.add(defaultKeywords.get(topKeywords.size()));
-        }
+        defaultKeywords.stream()
+                .filter(keyword -> !topKeywords.contains(keyword))
+                .limit(3 - topKeywords.size())
+                .forEach(topKeywords::add);
 
         return new HomeDto(nowUser.getNickname(), ownedCardCount, topKeywords);
 


### PR DESCRIPTION
## ℹ️ PR Type

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #이슈번호

## 🔎 작업 내용
 홈화면 검색 키워드가 중복되는 것을 방지하였다

## 📩 API Test
- 기존에 중복된 키워드가 뜨던 문제
<img width="700" alt="스크린샷 2024-04-19 오후 3 23 13" src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/48059cac-467c-4368-9fe4-d9cf6f42f319">

- 해결
<img width="700" alt="스크린샷 2024-04-19 오후 3 23 40" src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/749850ff-70bb-4d19-92cc-05fbfed193c2">


## ➰ ETC
