### PR TITLE
[Fix] 회원 탈퇴 api 수정

### DIFF
--- a/src/main/java/ewha/lux/once/domain/user/service/UserService.java
+++ b/src/main/java/ewha/lux/once/domain/user/service/UserService.java
@@ -1,17 +1,15 @@
 package ewha.lux.once.domain.user.service;
 
-import ewha.lux.once.domain.card.entity.Card;
-import ewha.lux.once.domain.card.entity.CardCompany;
-import ewha.lux.once.domain.card.entity.CardType;
-import ewha.lux.once.domain.card.entity.OwnedCard;
+import ewha.lux.once.domain.card.entity.*;
+import ewha.lux.once.domain.home.entity.Announcement;
+import ewha.lux.once.domain.home.entity.ChatHistory;
+import ewha.lux.once.domain.home.entity.FCMToken;
+import ewha.lux.once.domain.home.entity.Favorite;
 import ewha.lux.once.domain.user.dto.*;
 import ewha.lux.once.domain.user.entity.Users;
 import ewha.lux.once.global.common.CustomException;
 import ewha.lux.once.global.common.ResponseCode;
-import ewha.lux.once.global.repository.CardCompanyRepository;
-import ewha.lux.once.global.repository.CardRepository;
-import ewha.lux.once.global.repository.OwnedCardRepository;
-import ewha.lux.once.global.repository.UsersRepository;
+import ewha.lux.once.global.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -36,6 +34,11 @@ public class UserService implements UserDetailsService {
     private final CardRepository cardRepository;
     private final CardCompanyRepository cardCompanyRepository;
     private final OwnedCardRepository ownedCardRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final ChatHistoryRepository chatHistoryRepository;
+    private final ConnectedCardCompanyRepository connectedCardCompanyRepository;
+    private final FavoriteRepository favoriteRepository;
+    private final FCMTokenRepository fcmTokenRepository;
     private final S3Uploader s3Uploader;
 
     public Users signup(SignupRequestDto request) throws CustomException, ParseException {
@@ -94,6 +97,18 @@ public class UserService implements UserDetailsService {
     }
 
     public void deleteUsers(Users nowUser) throws CustomException {
+        List <Announcement> announcementList = announcementRepository.findAnnouncementByUsers(nowUser);
+        announcementRepository.deleteAll(announcementList);
+        List <ChatHistory> chatHistoryList = chatHistoryRepository.findByUsers(nowUser);
+        chatHistoryRepository.deleteAll(chatHistoryList);
+        List <ConnectedCardCompany> connectedCardCompanyList = connectedCardCompanyRepository.findAllByUsers(nowUser);
+        connectedCardCompanyRepository.deleteAll(connectedCardCompanyList);
+        List<OwnedCard> ownedCardList = ownedCardRepository.findOwnedCardByUsers(nowUser);
+        ownedCardRepository.deleteAll(ownedCardList);
+        List <Favorite> favoriteList = favoriteRepository.findAllByUsers(nowUser).get();
+        favoriteRepository.deleteAll(favoriteList);
+        List <FCMToken> fcmTokenList = fcmTokenRepository.findAllByUsers(nowUser);
+        fcmTokenRepository.deleteAll(fcmTokenList);
         usersRepository.delete(nowUser);
         return;
     }


### PR DESCRIPTION
## ℹ️ PR Type

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #83

## 🔎 작업 내용
회원 탈퇴 시 User를 외래키로 가지고 있는 객체가 있는 경우 오류 발생
User 삭제 전에 해당 사용자의 모든 기록을 지움


## 📩 API Test
<img width="600" alt="스크린샷 2024-05-03 오전 5 32 34" src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/0b45e0c8-71bc-4a8c-8538-f589d9bd56c0">



## ➰ ETC
