### PR TITLE
[Feat] 푸시 알림 페이지 이동을 위한 알림id추가 (#72)

### DIFF
--- a/src/main/java/ewha/lux/once/domain/home/dto/AnnouncementRequestDto.java
+++ b/src/main/java/ewha/lux/once/domain/home/dto/AnnouncementRequestDto.java
@@ -11,4 +11,5 @@ public class AnnouncementRequestDto {
     private String targetToken;
     private String title;
     private String body;
+    private String announceId;
 }

--- a/src/main/java/ewha/lux/once/domain/home/service/AnnouncementService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/AnnouncementService.java
@@ -78,7 +78,7 @@ public class AnnouncementService {
             List<FCMToken> fcmTokens = fcmTokenRepository.findAllByUsers(users);
             for ( FCMToken fcmToken : fcmTokens){
                 String token = fcmToken.getToken();
-                firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,"목표 응원 알림",content));
+                firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,"목표 응원 알림",content,announcement.getId().toString()));
             }
         }
     }
@@ -112,7 +112,7 @@ public class AnnouncementService {
             List<FCMToken> fcmTokens = fcmTokenRepository.findAllByUsers(users);
             for ( FCMToken fcmToken : fcmTokens){
                 String token = fcmToken.getToken();
-                firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,currentDate+"월 실적 알림",content));
+                firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,currentDate+"월 실적 알림",content,announcement.getId().toString()));
             }
 
         }

--- a/src/main/java/ewha/lux/once/domain/home/service/FirebaseCloudMessageService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/FirebaseCloudMessageService.java
@@ -29,6 +29,7 @@ public class FirebaseCloudMessageService {
         Message message = Message.builder()
                 .setToken(requestDTO.getTargetToken())
                 .setNotification(notification)
+                .putData("announceId",requestDTO.getAnnounceId() )
                 .build();
         try {
             firebaseMessaging.send(message);

--- a/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
+++ b/src/main/java/ewha/lux/once/domain/home/service/HomeService.java
@@ -20,8 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
@@ -45,7 +43,6 @@ public class HomeService {
     private final FCMTokenRepository fcmTokenRepository;
     private final FirebaseCloudMessageService firebaseCloudMessageService;
     private final BeaconRepository beaconRepository;
-    private final CODEFAsyncService codefAsyncService;
 
     // 챗봇 카드 추천
     public ChatDto getHomeChat(Users nowUser, String keyword, int paymentAmount) throws CustomException {
@@ -337,7 +334,7 @@ public class HomeService {
         }
 
         String contents = dto.getStoreName()+" 근처시군요.\n"+card.getName()+" 사용해 보세요!";
-        String title = dto.getStoreName()+" 근처시군요";
+        String title = dto.getStoreName()+" 근처시군요.";
         String content = card.getName()+" 사용해 보세요!";
         String moreInfo = dto.getLatitude()+", "+dto.getLongitude();
         Announcement announcement = Announcement.builder()
@@ -351,7 +348,7 @@ public class HomeService {
         for ( FCMToken fcmToken : fcmTokens){
 
             String token = fcmToken.getToken();
-            firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,title,content));
+            firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,title,content,announcement.getId().toString()));
         }
     }
     public void postBeaconAnnouncement(BeaconRequestDto dto, Users nowUser)throws CustomException {
@@ -378,7 +375,7 @@ public class HomeService {
             throw new CustomException(ResponseCode.FAILED_TO_OPENAI_RECOMMEND);
         }
 
-        String title = beacon.getStore()+" 근처시군요";
+        String title = beacon.getStore()+" 근처시군요.";
         String content = card.getName()+" 사용해 보세요!";
         String contents = beacon.getStore()+" 근처시군요.\n"+card.getName()+" 사용해 보세요!";
 
@@ -393,7 +390,7 @@ public class HomeService {
         announcementRepository.save(announcement);
         for ( FCMToken fcmToken : fcmTokens){
             String token = fcmToken.getToken();
-            firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,title,content));
+            firebaseCloudMessageService.sendNotification(new AnnouncementRequestDto(token,title,content,announcement.getId().toString()));
         }
 
     }


### PR DESCRIPTION
## ℹ️ PR Type

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경변수, 빌드 관련 업데이트
- [ ] 기타


## 📍 Issue

> resolve #72

## 🔎 작업 내용
FCM 알림을 보낼 때 해당 announceId를 데이터에 추가하여, 푸시알림 클릭 시 해당 알림 상세 페이지로 이동하도록 한다

## 📩 API Test
<img src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/c1f91484-7809-437e-a753-e3adef68766d" width=300>
<img src="https://github.com/EWHA-LUX/ONCE-BE/assets/100216331/88c26e27-caa3-4b22-81ad-e84e7058e692" width=300>

알림 클릭 시, 오른쪽 화면과 같이 해당 알림 상세 조회 페이지로 이동

## ➰ ETC
